### PR TITLE
v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]
 
+## 1.1.1 - 2020-09-09
+
 ### Fixed
 
 - web vitals are no longer logged on pages when using the Live Preview functionality [#7](https://github.com/codewithkyle/craft-lightkeeper/issues/7)
+- performance emails check for the developers email address before sending
 
 ## 1.1.0 - 2020-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]
 
+## 1.1.0 - 2020-08-04
+
 ### Added
 
 - switched `{{ craft.lightkeeper.load() }}` to a template hook `{% hook 'lightkeeper' %}` [#4](https://github.com/codewithkyle/craft-lightkeeper/issues/4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]
 
+### Fixed
+
+- web vitals are no longer logged on pages when using the Live Preview functionality [#7](https://github.com/codewithkyle/craft-lightkeeper/issues/7)
+
 ## 1.1.0 - 2020-08-04
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "codewithkyle/lightkeeper",
     "description": "Lightkeeper integrates Google Lighthouse testing alongside continuous performance monitoring.",
     "type": "craft-plugin",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/Lightkeeper.php
+++ b/src/Lightkeeper.php
@@ -124,8 +124,12 @@ class Lightkeeper extends Plugin
         });
 
         Craft::$app->view->hook('lightkeeper', function(array &$context) {
-            $view = Craft::$app->getView();
-            $view->registerAssetBundle('codewithkyle\\lightkeeper\\assetbundles\\lightkeeper\\LightkeeperAsset');
+            $request = Craft::$app->getRequest();
+            if (!$request->getIsPreview())
+            {
+                $view = Craft::$app->getView();
+                $view->registerAssetBundle('codewithkyle\\lightkeeper\\assetbundles\\lightkeeper\\LightkeeperAsset');
+            }
         });
 
         Craft::info(

--- a/src/services/LightkeeperService.php
+++ b/src/services/LightkeeperService.php
@@ -214,14 +214,17 @@ class LightkeeperService extends Component
             }
 
             // Do we need to send an email?
-            if (!$passedAccessibility || !$passedBestPractices || !$passedPerformance)
+            if (!empty($settings['developerEmail']))
             {
-                $html = '
-                    The page <a href="' . $params['url'] . '" target="_blank">' . $params['url'] . '</a> has failed a Lighthouse audit:<br/>
-                    <strong>Performance:</strong> ' . $params['performance'] * 100 . '/' . $settings['minimumPerformance'] . '<br/>
-                    <strong>Accessibility:</strong> ' . $params['accessibility'] * 100 . '/' . $settings['minimumAccessibility'] . '<br/>
-                    <strong>Best Practices:</strong> ' . $params['bestPractices'] * 100 . '/' . $settings['minimumBestPractices'];
-                $this->sendMail($html, Craft::$app->getSystemName() . ' - Lighthouse Audit Failed', $settings['developerEmail']);
+                if (!$passedAccessibility || !$passedBestPractices || !$passedPerformance)
+                {
+                    $html = '
+                        The page <a href="' . $params['url'] . '" target="_blank">' . $params['url'] . '</a> has failed a Lighthouse audit:<br/>
+                        <strong>Performance:</strong> ' . $params['performance'] * 100 . '/' . $settings['minimumPerformance'] . '<br/>
+                        <strong>Accessibility:</strong> ' . $params['accessibility'] * 100 . '/' . $settings['minimumAccessibility'] . '<br/>
+                        <strong>Best Practices:</strong> ' . $params['bestPractices'] * 100 . '/' . $settings['minimumBestPractices'];
+                    $this->sendMail($html, Craft::$app->getSystemName() . ' - Lighthouse Audit Failed', $settings['developerEmail']);
+                }
             }
         }
 


### PR DESCRIPTION
### Fixed

- web vitals are no longer logged on pages when using the Live Preview functionality [#7](https://github.com/codewithkyle/craft-lightkeeper/issues/7)
- performance emails check for the developers email address before sending